### PR TITLE
Added leading Icon to the missing preferences

### DIFF
--- a/ComposePrefs3/src/main/java/com/jamal/composeprefs3/ui/prefs/DropDownPref.kt
+++ b/ComposePrefs3/src/main/java/com/jamal/composeprefs3/ui/prefs/DropDownPref.kt
@@ -33,6 +33,7 @@ import java.lang.Exception
  * @param dropdownBackgroundColor Color of the dropdown menu
  * @param textColor Text colour of the [title] and [summary]
  * @param enabled If false, this Pref cannot be clicked and the dropdown menu will not show.
+ * @param leadingIcon Icon which is positioned at the start of the Pref
  * @param entries Map of keys to values for entries that should be shown in the DropDown.
  */
 @Composable
@@ -47,6 +48,7 @@ fun DropDownPref(
     dropdownBackgroundColor: Color? = null,
     textColor: Color = MaterialTheme.colorScheme.onBackground,
     enabled: Boolean = true,
+    leadingIcon: @Composable (() -> Unit)? = null,
     entries: Map<String, String> = mapOf()
 ) {
 
@@ -83,6 +85,7 @@ fun DropDownPref(
                 useSelectedAsSummary && value == null -> "Not Set"
                 else -> summary
             },
+            leadingIcon = leadingIcon,
             textColor = textColor,
             enabled = enabled,
             onClick = {

--- a/ComposePrefs3/src/main/java/com/jamal/composeprefs3/ui/prefs/EditTextPref.kt
+++ b/ComposePrefs3/src/main/java/com/jamal/composeprefs3/ui/prefs/EditTextPref.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.launch
  * @param dialogBackgroundColor Color of the dropdown menu
  * @param textColor Text colour of the [title] and [summary]
  * @param enabled If false, this Pref cannot be clicked.
+ * @param leadingIcon Icon which is positioned at the start of the Pref
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @ExperimentalComposeUiApi
@@ -54,6 +55,7 @@ fun EditTextPref(
     dialogBackgroundColor: Color = MaterialTheme.colorScheme.background,
     textColor: Color = MaterialTheme.colorScheme.onBackground,
     enabled: Boolean = true,
+    leadingIcon: @Composable (() -> Unit)? = null
 ) {
 
     var showDialog by rememberSaveable { mutableStateOf(false) }
@@ -107,6 +109,7 @@ fun EditTextPref(
         summary = summary,
         textColor = textColor,
         enabled = enabled,
+        leadingIcon = leadingIcon,
         onClick = { if (enabled) showDialog = !showDialog },
     )
 

--- a/ComposePrefs3/src/main/java/com/jamal/composeprefs3/ui/prefs/ListPref.kt
+++ b/ComposePrefs3/src/main/java/com/jamal/composeprefs3/ui/prefs/ListPref.kt
@@ -36,6 +36,7 @@ import java.lang.Exception
  * @param selectionColor Colour of the radiobutton of the selected item
  * @param buttonColor Colour of the cancel button
  * @param enabled If false, this Pref cannot be clicked and the Dialog cannot be shown.
+ * @param leadingIcon Icon which is positioned at the start of the Pref
  * @param entries Map of keys to values for entries that should be shown in the Dialog.
  */
 @OptIn(ExperimentalMaterial3Api::class)
@@ -55,6 +56,7 @@ fun ListPref(
     selectionColor: Color = MaterialTheme.colorScheme.primary,
     buttonColor: Color = MaterialTheme.colorScheme.primary,
     enabled: Boolean = true,
+    leadingIcon: @Composable (() -> Unit)? = null,
     entries: Map<String, String> = mapOf(), //TODO: Change to List?
 ) {
 
@@ -90,6 +92,7 @@ fun ListPref(
             useSelectedAsSummary && selected == null -> "Not Set"
             else -> summary
         },
+        leadingIcon = leadingIcon,
         modifier = modifier,
         textColor = textColor,
         enabled = true,

--- a/ComposePrefs3/src/main/java/com/jamal/composeprefs3/ui/prefs/MultiSelectListPref.kt
+++ b/ComposePrefs3/src/main/java/com/jamal/composeprefs3/ui/prefs/MultiSelectListPref.kt
@@ -35,6 +35,7 @@ import java.lang.Exception
  * @param dialogBackgroundColor Background color of the Dialog
  * @param textColor Text colour of the [title] and [summary]
  * @param enabled If false, this Pref cannot be clicked and the Dialog cannot be shown.
+ * @param leadingIcon Icon which is positioned at the start of the Pref
  * @param entries Map of keys to values for entries that should be shown in the Dialog.
  */
 @OptIn(ExperimentalMaterial3Api::class)
@@ -50,6 +51,7 @@ fun MultiSelectListPref(
     dialogBackgroundColor: Color = MaterialTheme.colorScheme.surface,
     textColor: Color = MaterialTheme.colorScheme.onBackground,
     enabled: Boolean = true,
+    leadingIcon: @Composable (() -> Unit)? = null,
     entries: Map<String, String> = mapOf() //TODO: Change to List?
 ) {
 
@@ -89,6 +91,7 @@ fun MultiSelectListPref(
         title = title,
         modifier = modifier,
         summary = summary,
+        leadingIcon = leadingIcon,
         textColor = textColor,
         enabled = true,
         onClick = { if (enabled) showDialog = !showDialog },


### PR DESCRIPTION
I saw that some of the preference composables were missing the option to add a leading icon. 
Changed the following:
* DropDownPref
* EditTextPref
* ListPref
* MultiSelectListPref
